### PR TITLE
feat(terraform): Add outputs for network resources

### DIFF
--- a/terraform/gcp/01-network/outputs.tf
+++ b/terraform/gcp/01-network/outputs.tf
@@ -1,29 +1,9 @@
-output "vpc_network_name" {
-  description = "The name of the VPC network"
-  value       = google_compute_network.vpc_network.name
+output "network" {
+  description = "The VPC network object"
+  value       = google_compute_network.vpc_network
 }
 
-output "vpc_network_self_link" {
-  description = "The self_link of the VPC network"
-  value       = google_compute_network.vpc_network.self_link
-}
-
-output "gke_subnet_name" {
-  description = "The name of the GKE subnet"
-  value       = google_compute_subnetwork.gke_subnet.name
-}
-
-output "gke_subnet_self_link" {
-  description = "The self_link of the GKE subnet"
-  value       = google_compute_subnetwork.gke_subnet.self_link
-}
-
-output "gke_subnet_pods_range_name" {
-  description = "The name of the secondary IP range for pods"
-  value       = google_compute_subnetwork.gke_subnet.secondary_ip_range[0].range_name
-}
-
-output "gke_subnet_services_range_name" {
-  description = "The name of the secondary IP range for services"
-  value       = google_compute_subnetwork.gke_subnet.secondary_ip_range[1].range_name
+output "subnet" {
+  description = "The GKE subnet object"
+  value       = google_compute_subnetwork.gke_subnet
 }

--- a/terraform/gcp/01-network/outputs.tf
+++ b/terraform/gcp/01-network/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_network_name" {
+  description = "The name of the VPC network"
+  value       = google_compute_network.vpc_network.name
+}
+
+output "vpc_network_self_link" {
+  description = "The self_link of the VPC network"
+  value       = google_compute_network.vpc_network.self_link
+}
+
+output "gke_subnet_name" {
+  description = "The name of the GKE subnet"
+  value       = google_compute_subnetwork.gke_subnet.name
+}
+
+output "gke_subnet_self_link" {
+  description = "The self_link of the GKE subnet"
+  value       = google_compute_subnetwork.gke_subnet.self_link
+}
+
+output "gke_subnet_pods_range_name" {
+  description = "The name of the secondary IP range for pods"
+  value       = google_compute_subnetwork.gke_subnet.secondary_ip_range[0].range_name
+}
+
+output "gke_subnet_services_range_name" {
+  description = "The name of the secondary IP range for services"
+  value       = google_compute_subnetwork.gke_subnet.secondary_ip_range[1].range_name
+}


### PR DESCRIPTION
This commit introduces a new `outputs.tf` file in the `terraform/gcp/01-network` directory.

This change exposes key attributes of the created VPC network and subnet, such as their names and self-links. This allows other Terraform configurations to easily reference and use these network resources.